### PR TITLE
implement user login

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -1,0 +1,11 @@
+# Kodi Media Center language file
+msgid ""
+msgstr ""
+
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: en\n"
+
+msgctxt "#30200"
+msgid "cookie"
+msgstr ""

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -1,0 +1,3 @@
+<settings>
+    <setting id="cookie" type="text" label="30200" default="" enable="true"/>
+</settings>


### PR DESCRIPTION
Now that season 4 is rolling out, it appears they require users to login to a free account. This commit adds a login form to the main page, and gets the necessary cookies to authenticate.

This is the first time I have worked with Kodi, so apologies if this is not the most elegant solution. As it stands, these changes are not fully ready to be merged because cached pages hide the updated response. I disabled page caching in my fork, however I opted to leave that decision up to you. 

I appreciate your work in creating this add-on, and hope that this helps make the plugin even better!